### PR TITLE
[37기 김대호] Add : 결제 페이지 레이아웃 구현

### DIFF
--- a/src/pages/payPage/OrderInfo.js
+++ b/src/pages/payPage/OrderInfo.js
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 
-function OrderInfo() {
+function OrderInfo({
+  choiceMessages,
+  isOrderInput,
+  inputMessages,
+  orderMessages,
+}) {
   return (
     <div>
       <div className="order-info">
@@ -11,13 +16,25 @@ function OrderInfo() {
         </div>
         <div className="order-message">
           <strong>배송메세지</strong>
-          <select name="choice-message">
-            <option value="1">선택해주세요</option>
-            <option value="2">부재 시 경비실에 맡겨주세요</option>
-            <option value="3">직접 받을게요</option>
-            <option value="4">배송 전에 연락주세요</option>
-            <option value="5">직접 입력</option>
-          </select>
+          <div className="order-choice-wrap">
+            <select name="choice-message" onChange={choiceMessages}>
+              <option value="선택해주세요">선택해주세요</option>
+              <option value="부재 시 경비실에 맡겨주세요">
+                부재 시 경비실에 맡겨주세요
+              </option>
+              <option value="직접 받을게요">직접 받을게요</option>
+              <option value="배송 전에 연락주세요">배송 전에 연락주세요</option>
+              <option value="">직접 입력</option>
+            </select>
+            {isOrderInput && (
+              <input
+                type="text"
+                placeholder="배송지를 입력해주세요"
+                value={orderMessages}
+                onChange={inputMessages}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/payPage/OrderInfo.js
+++ b/src/pages/payPage/OrderInfo.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+function OrderInfo() {
+  return (
+    <div>
+      <div className="order-info">
+        <div className="order-address">
+          <strong>배송지</strong>
+          <p>서울시 동작구 상도동 356-6 1층 101호</p>
+          <a href="#!">배송지 정보 변경</a>
+        </div>
+        <div className="order-message">
+          <strong>배송메세지</strong>
+          <select name="choice-message">
+            <option value="1">선택해주세요</option>
+            <option value="2">부재 시 경비실에 맡겨주세요</option>
+            <option value="3">직접 받을게요</option>
+            <option value="4">배송 전에 연락주세요</option>
+            <option value="5">직접 입력</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OrderInfo;

--- a/src/pages/payPage/OrderInfo.js
+++ b/src/pages/payPage/OrderInfo.js
@@ -1,18 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 function OrderInfo({
   choiceMessages,
   isOrderInput,
   inputMessages,
   orderMessages,
+  address,
 }) {
   return (
     <div>
       <div className="order-info">
         <div className="order-address">
           <strong>배송지</strong>
-          <p>서울시 동작구 상도동 356-6 1층 101호</p>
-          <a href="#!">배송지 정보 변경</a>
+          <p>{address}</p>
         </div>
         <div className="order-message">
           <strong>배송메세지</strong>

--- a/src/pages/payPage/PayPage.js
+++ b/src/pages/payPage/PayPage.js
@@ -1,11 +1,93 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import OrderInfo from './OrderInfo';
+import './PayPage.scss';
+import ProductInfo from './ProductInfo';
 
 function PayPage() {
-    return (
-        <div>
-            
+  const [check, setCheck] = useState(false);
+
+  console.log(typeof check); //지워도 될 거 같은데?
+  const checkTeset = e => {
+    console.log('체크 박스 여부', e.target.checked);
+    setCheck(e.target.checked);
+  };
+
+  const clickTest = () => {
+    alert('결제가 완료되었습니다');
+    //통신 데이터 전송
+  };
+
+  //통신 테스트 데이터 확인용
+  const [productData, setProductData] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/payTest.json')
+      .then(response => response.json())
+      .then(result => setProductData(result));
+  }, []);
+
+  useEffect(() => {
+    console.log('장바구니에 담긴 애들을 전체 받아옴', productData);
+
+    productData.map(item => {
+      const test = [];
+      if (item.check === true) {
+        test.push(item);
+      }
+      console.log('check가 true인 애들만 필터링한 값', test);
+    });
+  }, []);
+
+  return (
+    <div className="pay-wrap">
+      <h1>주문/결제</h1>
+      <div className="product-wrap">
+        <h2>제품정보</h2>
+        <ProductInfo />
+      </div>
+      <div className="orderer-wrap">
+        <h2>주문자 정보</h2>
+        <div className="orderer-info">
+          <p>주문자 정보</p>
+          <div className="orderer-match">
+            <p>김대호</p>
+            <p>eogh773@naver.com</p>
+            <p>010-3633-3190</p>
+          </div>
         </div>
-    );
+      </div>
+      <div className="order-wrap">
+        <h2>배송 정보</h2>
+        <OrderInfo />
+      </div>
+      <div className="payment-wrap">
+        <h2 className="pay-info">결제 정보</h2>
+        <div className="payment-box">
+          <p className="box-start">합계</p>
+          <strong>₩2,500</strong>
+          <p>+ 배송비</p>
+          <strong>무료</strong>
+          <p>= 최종 결제 금액</p>
+          <h3>₩2,500</h3>
+        </div>
+      </div>
+      <div className="pay-footer">
+        <label>
+          <input
+            type="checkbox"
+            name="color"
+            value="blue"
+            onChange={checkTeset}
+          />
+          <span>(필수)</span>구매하실 제품의 결제정보를 확인하였으며, 구매진행에
+          동의합니다.
+        </label>
+        <button disabled={check === false ? true : false} onClick={clickTest}>
+          ₩2,500원 결제하기
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default PayPage;

--- a/src/pages/payPage/PayPage.js
+++ b/src/pages/payPage/PayPage.js
@@ -1,25 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import OrderInfo from './OrderInfo';
-import './PayPage.scss';
 import ProductInfo from './ProductInfo';
+import TotalOrder from './TotalOrder';
+import './PayPage.scss';
 
 function PayPage() {
-  const [payData, setPayData] = useState([]);
-
-  useEffect(() => {
-    fetch('http://192.168.228.223:3000/products/showproduct/3', {
-      headers: {
-        authorization:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjQwMDk3ODR9.nvQGE9HLe8n-JCgqqRk3O-2dGEujzQhWIgm0WyCKN60',
-      },
-    })
-      .then(res => res.json())
-      .then(data => {
-        setPayData(data);
-      });
-  }, []);
-  console.log(payData);
-
   const [check, setCheck] = useState(false);
 
   const isCheck = e => {
@@ -43,48 +29,63 @@ function PayPage() {
     selecter === 4 ? setIsOrderInput(true) : setIsOrderInput(false);
   }, [choiceMessages]);
 
-  const [testData, setTestData] = useState([]);
+  const location = useLocation();
+  const { product_id } = location.state;
+
+  const [userData, setUserData] = useState([]);
+  const [productData, setProductData] = useState([]);
+  const { email, name, address } = userData;
+  const accessToken = localStorage.getItem('accessToken'); //로그인 시 발행 토큰
+
+  const checkedQueryString = () => {
+    let checkedProducts = '';
+    for (let i = 0; i < product_id.length; i++) {
+      checkedProducts += `productId=${product_id[i]}&`;
+    }
+    return checkedProducts.slice(0, -1);
+  };
+
 
   useEffect(() => {
-    fetch('/data/payTest.json')
-      .then(response => response.json())
-      .then(result => setTestData(result));
-  }, []);
-
-  const payBtn = () => {
-    fetch('http://192.168.192.223:3000/order', {
-      method: 'POST',
+    fetch('./data/users.json', {
       headers: {
         authorization:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjM3NTcxNTZ9.aWMCo2vBo_8cEUxE1HwGRekiuQvgRYEwS09JdFiQDmw',
-        'Content-Type': 'application/json;charset=utf-8',
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjQwMDk3ODR9.nvQGE9HLe8n-JCgqqRk3O-2dGEujzQhWIgm0WyCKN60',
       },
-      body: JSON.stringify({
-        total: testData[0].price,
-        reqMessage: orderMessages,
-        address: testData[0].order,
-      }),
     })
-      .then(response => response.json())
-      .then(result => console.log(result));
-    alert('결제가 완료되었습니다');
-  };
+      .then(res => res.json())
+      .then(data => {
+        setUserData(data.message);
+      });
+  }, []);
+
+  useEffect(() => {
+    fetch('./data/products.json', {
+      headers: {
+        authorization:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjQwMDk3ODR9.nvQGE9HLe8n-JCgqqRk3O-2dGEujzQhWIgm0WyCKN60',
+      },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setProductData(data.message);
+      });
+  }, []);
 
   return (
     <div className="pay-wrap">
       <h1>주문/결제</h1>
       <div className="product-wrap">
         <h2>제품정보</h2>
-        <ProductInfo />
+        <ProductInfo productData={productData} />
       </div>
       <div className="orderer-wrap">
         <h2>주문자 정보</h2>
         <div className="orderer-info">
           <p>주문자 정보</p>
           <div className="orderer-match">
-            <p>김대호</p>
-            <p>eogh773@naver.com</p>
-            <p>010-3633-3190</p>
+            <p>{name}</p>
+            <p>{email}</p>
           </div>
         </div>
       </div>
@@ -92,32 +93,21 @@ function PayPage() {
         <h2>배송 정보</h2>
         <OrderInfo
           choiceMessages={choiceMessages}
-          isOrderInput={isOrderInput}
           inputMessages={inputMessages}
+          isOrderInput={isOrderInput}
           orderMessages={orderMessages}
+          address={address}
         />
       </div>
-      <div className="payment-wrap">
-        <h2 className="pay-info">결제 정보</h2>
-        <div className="payment-box">
-          <p className="box-start">합계</p>
-          <strong>₩2,500</strong>
-          <p>+ 배송비</p>
-          <strong>무료</strong>
-          <p>= 최종 결제 금액</p>
-          <h3>₩2,500</h3>
-        </div>
-      </div>
-      <div className="pay-footer">
-        <label>
-          <input type="checkbox" name="color" value="blue" onChange={isCheck} />
-          <span>(필수)</span>구매하실 제품의 결제정보를 확인하였으며, 구매진행에
-          동의합니다.
-        </label>
-        <button disabled={check === false ? true : false} onClick={payBtn}>
-          ₩2,500원 결제하기
-        </button>
-      </div>
+      <TotalOrder
+        isCheck={isCheck}
+        check={check}
+        orderMessages={orderMessages}
+        address={address}
+        testProductId={testProductId}
+        productData={productData}
+        product_id={product_id}
+      />
     </div>
   );
 }

--- a/src/pages/payPage/PayPage.js
+++ b/src/pages/payPage/PayPage.js
@@ -4,39 +4,71 @@ import './PayPage.scss';
 import ProductInfo from './ProductInfo';
 
 function PayPage() {
+  const [payData, setPayData] = useState([]);
+
+  useEffect(() => {
+    fetch('http://192.168.228.223:3000/products/showproduct/3', {
+      headers: {
+        authorization:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjQwMDk3ODR9.nvQGE9HLe8n-JCgqqRk3O-2dGEujzQhWIgm0WyCKN60',
+      },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setPayData(data);
+      });
+  }, []);
+  console.log(payData);
+
   const [check, setCheck] = useState(false);
 
-  console.log(typeof check); //지워도 될 거 같은데?
-  const checkTeset = e => {
-    console.log('체크 박스 여부', e.target.checked);
+  const isCheck = e => {
     setCheck(e.target.checked);
   };
 
-  const clickTest = () => {
-    alert('결제가 완료되었습니다');
-    //통신 데이터 전송
+  const [selecter, setSelecter] = useState('');
+  const [orderMessages, setOrderMessages] = useState('');
+  const [isOrderInput, setIsOrderInput] = useState(false);
+
+  const choiceMessages = e => {
+    setSelecter(e.target.selectedIndex);
+    setOrderMessages(e.target.value);
   };
 
-  //통신 테스트 데이터 확인용
-  const [productData, setProductData] = useState([]);
+  const inputMessages = e => {
+    setOrderMessages(e.target.value);
+  };
+
+  useEffect(() => {
+    selecter === 4 ? setIsOrderInput(true) : setIsOrderInput(false);
+  }, [choiceMessages]);
+
+  const [testData, setTestData] = useState([]);
 
   useEffect(() => {
     fetch('/data/payTest.json')
       .then(response => response.json())
-      .then(result => setProductData(result));
+      .then(result => setTestData(result));
   }, []);
 
-  useEffect(() => {
-    console.log('장바구니에 담긴 애들을 전체 받아옴', productData);
-
-    productData.map(item => {
-      const test = [];
-      if (item.check === true) {
-        test.push(item);
-      }
-      console.log('check가 true인 애들만 필터링한 값', test);
-    });
-  }, []);
+  const payBtn = () => {
+    fetch('http://192.168.192.223:3000/order', {
+      method: 'POST',
+      headers: {
+        authorization:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjM3NTcxNTZ9.aWMCo2vBo_8cEUxE1HwGRekiuQvgRYEwS09JdFiQDmw',
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+      body: JSON.stringify({
+        total: testData[0].price,
+        reqMessage: orderMessages,
+        address: testData[0].order,
+      }),
+    })
+      .then(response => response.json())
+      .then(result => console.log(result));
+    alert('결제가 완료되었습니다');
+  };
 
   return (
     <div className="pay-wrap">
@@ -58,7 +90,12 @@ function PayPage() {
       </div>
       <div className="order-wrap">
         <h2>배송 정보</h2>
-        <OrderInfo />
+        <OrderInfo
+          choiceMessages={choiceMessages}
+          isOrderInput={isOrderInput}
+          inputMessages={inputMessages}
+          orderMessages={orderMessages}
+        />
       </div>
       <div className="payment-wrap">
         <h2 className="pay-info">결제 정보</h2>
@@ -73,16 +110,11 @@ function PayPage() {
       </div>
       <div className="pay-footer">
         <label>
-          <input
-            type="checkbox"
-            name="color"
-            value="blue"
-            onChange={checkTeset}
-          />
+          <input type="checkbox" name="color" value="blue" onChange={isCheck} />
           <span>(필수)</span>구매하실 제품의 결제정보를 확인하였으며, 구매진행에
           동의합니다.
         </label>
-        <button disabled={check === false ? true : false} onClick={clickTest}>
+        <button disabled={check === false ? true : false} onClick={payBtn}>
           ₩2,500원 결제하기
         </button>
       </div>

--- a/src/pages/payPage/PayPage.scss
+++ b/src/pages/payPage/PayPage.scss
@@ -176,7 +176,6 @@
       }
 
       strong {
-        width: 50px;
         font-size: 30px;
         margin: 20px;
       }

--- a/src/pages/payPage/PayPage.scss
+++ b/src/pages/payPage/PayPage.scss
@@ -1,8 +1,8 @@
 .pay-wrap {
-  margin-top: 200px; /*지울 거*/
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 80px;
 
   h1 {
     font-size: 50px;
@@ -13,13 +13,13 @@
     display: block;
     margin: 0 auto;
     margin-top: 50px;
-    width: 80%;
+    width: 1330px;
     font-size: 30px;
     border-bottom: 1px solid rgb(142, 141, 141);
   }
 
   .product-wrap {
-    width: 100%;
+    width: 1650px;
     margin-top: 100px;
 
     .info-box {
@@ -31,7 +31,7 @@
         display: flex;
         justify-content: space-around;
         align-items: center;
-        width: 80%;
+        width: 1330px;
         height: 60px;
         border-bottom: 1px solid rgb(142, 141, 141);
 
@@ -45,12 +45,19 @@
         display: flex;
         justify-content: space-around;
         align-items: center;
-        width: 80%;
+        width: 1330px;
         margin: 10px;
         padding-bottom: 20px;
         border-bottom: 1px solid black;
 
+        strong {
+          position: relative;
+          right: 5px;
+          font-size: 20px;
+        }
+
         p {
+          font-size: 15px;
           width: 140px;
         }
 
@@ -61,14 +68,14 @@
     }
   }
   .orderer-wrap {
-    width: 100%;
+    width: 1650px;
     margin-top: 20px;
 
     .orderer-info {
       display: flex;
       justify-content: flex-start;
       align-items: center;
-      width: 80%;
+      width: 1330px;
       height: 140px;
       margin: 0 auto;
       border-bottom: 1px solid black;
@@ -90,7 +97,7 @@
   }
 
   .order-wrap {
-    width: 100%;
+    width: 1650px;
     margin-top: 20px;
 
     .order-info {
@@ -98,7 +105,7 @@
       flex-direction: column;
       justify-content: center;
       align-items: flex-start;
-      width: 80%;
+      width: 1330px;
       height: 140px;
       margin: 0 auto;
       padding-left: 50px;
@@ -107,6 +114,21 @@
       strong {
         font-size: 20px;
         margin-right: 10px;
+      }
+
+      .order-message {
+        display: flex;
+
+        .order-choice-wrap {
+          position: relative;
+          display: flex;
+          flex-direction: column;
+
+          input {
+            position: relative;
+            top: 10px;
+          }
+        }
       }
 
       .order-address {
@@ -126,7 +148,7 @@
   }
 
   .payment-wrap {
-    width: 100%;
+    width: 1630px;
     margin-top: 20px;
 
     h2 {
@@ -140,7 +162,7 @@
       justify-content: center;
       align-items: center;
       border-radius: 5px;
-      width: 80%;
+      width: 1350px;
       height: 80px;
       margin: 0 auto;
 

--- a/src/pages/payPage/PayPage.scss
+++ b/src/pages/payPage/PayPage.scss
@@ -1,0 +1,194 @@
+.pay-wrap {
+  margin-top: 200px; /*지울 거*/
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  h1 {
+    font-size: 50px;
+    margin: 0 auto;
+  }
+
+  h2 {
+    display: block;
+    margin: 0 auto;
+    margin-top: 50px;
+    width: 80%;
+    font-size: 30px;
+    border-bottom: 1px solid rgb(142, 141, 141);
+  }
+
+  .product-wrap {
+    width: 100%;
+    margin-top: 100px;
+
+    .info-box {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      .product-table {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        width: 80%;
+        height: 60px;
+        border-bottom: 1px solid rgb(142, 141, 141);
+
+        p {
+          width: 150px;
+          font-size: 17px;
+        }
+      }
+
+      .product-page {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        width: 80%;
+        margin: 10px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid black;
+
+        p {
+          width: 140px;
+        }
+
+        img {
+          width: 150px;
+        }
+      }
+    }
+  }
+  .orderer-wrap {
+    width: 100%;
+    margin-top: 20px;
+
+    .orderer-info {
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      width: 80%;
+      height: 140px;
+      margin: 0 auto;
+      border-bottom: 1px solid black;
+
+      p {
+        font-size: 20px;
+        margin-left: 50px;
+      }
+
+      .orderer-match {
+        margin-left: 140px;
+
+        p {
+          margin: 5px;
+          font-size: 16px;
+        }
+      }
+    }
+  }
+
+  .order-wrap {
+    width: 100%;
+    margin-top: 20px;
+
+    .order-info {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      width: 80%;
+      height: 140px;
+      margin: 0 auto;
+      padding-left: 50px;
+      border-bottom: 1px solid black;
+
+      strong {
+        font-size: 20px;
+        margin-right: 10px;
+      }
+
+      .order-address {
+        display: flex;
+        margin-bottom: 20px;
+
+        p {
+          margin-top: 3px;
+        }
+
+        a {
+          font-size: 18px;
+          margin-left: 20px;
+        }
+      }
+    }
+  }
+
+  .payment-wrap {
+    width: 100%;
+    margin-top: 20px;
+
+    h2 {
+      border-bottom: 1px solid rgba(0, 0, 0, 0);
+      margin-bottom: 20px;
+    }
+
+    .payment-box {
+      background: rgb(240, 239, 239);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-radius: 5px;
+      width: 80%;
+      height: 80px;
+      margin: 0 auto;
+
+      p {
+        font-size: 30px;
+        margin-left: 150px;
+      }
+
+      .box-start {
+        margin-left: 20px;
+      }
+
+      strong {
+        width: 50px;
+        font-size: 30px;
+        margin: 20px;
+      }
+
+      h3 {
+        font-size: 30px;
+        color: rgb(117, 178, 24);
+        margin-left: 20px;
+      }
+    }
+  }
+  .pay-footer {
+    display: flex;
+    flex-direction: column;
+    margin: 100px 0;
+
+    span {
+      color: red;
+      margin-right: 2px;
+      font-size: 17px;
+    }
+
+    label {
+      font-size: 17px;
+    }
+
+    button {
+      background: rgb(34, 213, 46);
+      width: 100%;
+      height: 50px;
+      margin-top: 30px;
+      border: 1px solid rgba(0, 0, 0, 0);
+      color: white;
+      font-size: 18px;
+    }
+  }
+}

--- a/src/pages/payPage/ProductInfo.js
+++ b/src/pages/payPage/ProductInfo.js
@@ -1,35 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
-function ProductInfo() {
-  // const [productData, setProductData] = useState([]);      !!!제품 데이터 저장 스테이트!!!!
-
-  // useEffect(() => {
-  //   fetch('http://승렬님 아이피:포트/endPoint', {
-  //     method: 'GET',
-  //   })
-  //     .then(response => response.json())
-  //     .then(data => {
-  //       setProductData(data);
-  //     });
-  // }, []); !!!제품 정보 받는 통신, productData에서 받음!!!
-
-  // productData.map(item => {
-  //   return (
-  //     <div className="product-page" key={item.id}>
-  //       <img className="productImg" src={item.상품사진} alt="productImg" />
-  //       <div>
-  //         <strong>{item.상품명}</strong>
-  //         <p>{item.상품카테고리}</p>
-  //       </div>
-  //       <p>{item.상품가격}</p>
-  //       <p>{item.상품수량}</p>
-  //       <p>{item.상품가격 * item.상품수량}</p>
-  //     </div>
-  //   );
-  // });
-  // !!!실제 구성될 제품정보 컴포넌트!!!
-  // [{제품의 아이디, 제품의 수량}], [제품 합계 금액], [배송지 정보], [배송메세지]
-
+function ProductInfo({ productData }) {
   return (
     <div className="info-box">
       <div className="product-table">
@@ -39,20 +10,24 @@ function ProductInfo() {
         <p>금액</p>
         <p>합계 금액</p>
       </div>
-      <div className="product-page">
-        <img
-          className="productImg"
-          src={process.env.PUBLIC_URL + '/images/Nav/choco.jpeg'}
-          alt="productImg"
-        />
-        <div>
-          <strong>미니쉘</strong>
-          <p>초콜릿</p>
-        </div>
-        <p>1</p>
-        <p>(+2500원)</p>
-        <p>₩2,500</p>
-      </div>
+      {productData.map(item => {
+        return (
+          <div className="product-page" key={item.id}>
+            <img
+              className="productImg"
+              src="/images/Nav/choco.jpeg"
+              alt="productImg"
+            />
+            <div>
+              <strong>{item.name}</strong>
+              <p>{item.category_name}</p>
+            </div>
+            <p>{item.quantiny}</p>
+            <p>{item.price}</p>
+            <p>{item.price * item.quantiny}</p>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/payPage/ProductInfo.js
+++ b/src/pages/payPage/ProductInfo.js
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+
+function ProductInfo() {
+  // const [productData, setProductData] = useState([]);      !!!제품 데이터 저장 스테이트!!!!
+
+  // useEffect(() => {
+  //   fetch('http://10.58.62.11:3000/endPoint', {
+  //     method: 'GET',
+  //   })
+  //     .then(response => response.json())
+  //     .then(data => {
+  //       setProductData(data);
+  //     });
+  // }, []);      !!!제품 데이터 받는 통신!!!
+
+  // productData.map(item => {
+  //   return (
+  //     <div className="product-page">
+  //       <img className="productImg" src={item.상품사진} alt="productImg" />
+  //       <div>
+  //         <strong>{item.상품명}</strong>
+  //         <p>{item.상품카테고리}</p>
+  //       </div>
+  //       <p>{item.상품가격}</p>
+  //       <p>{item.상품수량}</p>
+  //       <p>{item.상품가격 * item.상품수량}</p>
+  //     </div>
+  //   );
+  // });        !!!실제 구성될 제품정보 컴포넌트!!!
+
+  //[{제품의 아이디, 제품의 수량}], [제품 합계 금액], [배송지 정보], [배송메세지]
+
+  return (
+    <div className="info-box">
+      <div className="product-table">
+        <p></p>
+        <p>제품정보</p>
+        <p>수량</p>
+        <p>금액</p>
+        <p>합계 금액</p>
+      </div>
+      <div className="product-page">
+        <img
+          className="productImg"
+          src={process.env.PUBLIC_URL + '/images/Nav/choco.jpeg'}
+          alt="productImg"
+        />
+        <div>
+          <strong>미니쉘</strong>
+          <p>초콜릿</p>
+        </div>
+        <p>1</p>
+        <p>(+2500원)</p>
+        <p>₩2,500</p>
+      </div>
+    </div>
+  );
+}
+
+export default ProductInfo;

--- a/src/pages/payPage/ProductInfo.js
+++ b/src/pages/payPage/ProductInfo.js
@@ -4,18 +4,18 @@ function ProductInfo() {
   // const [productData, setProductData] = useState([]);      !!!제품 데이터 저장 스테이트!!!!
 
   // useEffect(() => {
-  //   fetch('http://10.58.62.11:3000/endPoint', {
+  //   fetch('http://승렬님 아이피:포트/endPoint', {
   //     method: 'GET',
   //   })
   //     .then(response => response.json())
   //     .then(data => {
   //       setProductData(data);
   //     });
-  // }, []);      !!!제품 데이터 받는 통신!!!
+  // }, []); !!!제품 정보 받는 통신, productData에서 받음!!!
 
   // productData.map(item => {
   //   return (
-  //     <div className="product-page">
+  //     <div className="product-page" key={item.id}>
   //       <img className="productImg" src={item.상품사진} alt="productImg" />
   //       <div>
   //         <strong>{item.상품명}</strong>
@@ -26,14 +26,14 @@ function ProductInfo() {
   //       <p>{item.상품가격 * item.상품수량}</p>
   //     </div>
   //   );
-  // });        !!!실제 구성될 제품정보 컴포넌트!!!
-
-  //[{제품의 아이디, 제품의 수량}], [제품 합계 금액], [배송지 정보], [배송메세지]
+  // });
+  // !!!실제 구성될 제품정보 컴포넌트!!!
+  // [{제품의 아이디, 제품의 수량}], [제품 합계 금액], [배송지 정보], [배송메세지]
 
   return (
     <div className="info-box">
       <div className="product-table">
-        <p></p>
+        <p> </p>
         <p>제품정보</p>
         <p>수량</p>
         <p>금액</p>

--- a/src/pages/payPage/TotalOrder.js
+++ b/src/pages/payPage/TotalOrder.js
@@ -1,0 +1,64 @@
+import React from 'react';
+
+function TotalOrder({
+  isCheck,
+  check,
+  orderMessages,
+  address,
+  productData,
+  product_id,
+}) {
+
+  const totalData = productData.reduce((sum, num) => {
+    return (sum += num.price * num.quantiny);
+  }, 0);
+
+  const payBtn = () => {
+    fetch('http://192.168.87.223:3000/order', {
+      method: 'POST',
+      headers: {
+        authorization:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE2NjM3NTcxNTZ9.aWMCo2vBo_8cEUxE1HwGRekiuQvgRYEwS09JdFiQDmw',
+      },
+      body: JSON.stringify({
+        total: totalData,
+        reqMessage: orderMessages,
+        address: address,
+        prouctId: product_id,
+      }),
+    })
+      .then(response => response.json())
+      .then(result => {
+        console.log(result);
+      });
+    alert('결제가 완료되었습니다');
+  };
+
+  return (
+    <>
+      <div className="payment-wrap">
+        <h2 className="pay-info">결제 정보</h2>ㅔ
+        <div className="payment-box">
+          <p className="box-start">합계</p>
+          <strong>{'₩' + totalData}</strong>
+          <p>+ 배송비</p>
+          <strong>무료</strong>
+          <p>= 최종 결제 금액</p>
+          <h3>{'₩' + totalData}</h3>
+        </div>
+      </div>
+      <div className="pay-footer">
+        <label>
+          <input type="checkbox" name="color" value="blue" onChange={isCheck} />
+          <span>(필수)</span>구매하실 제품의 결제정보를 확인하였으며, 구매진행에
+          동의합니다.
+        </label>
+        <button disabled={check === false ? true : false} onClick={payBtn}>
+          {'₩' + totalData}원 결제하기
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default TotalOrder;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 결제 페이지 레이아웃 제작
- 해당 페이지의 제품정보, 배송자 정보, 배송지 정보 등 다양한 정보를 패치를 통해 구현
- 해당 페이지 하단의 (필수) 체크 박스 미클릭 시 결제 버튼 disabled
- 결제 완료 시 Nav 포인트 차감 반영 및 장바구니 목록 제거 및 구매 목록에 해당 제품 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
구현 목표랑 동일 이미지로 대체 
![결제페이지 전체](https://user-images.githubusercontent.com/98578138/191660211-15651b67-d5a9-408a-b3f2-1a0394b6d29e.png)

